### PR TITLE
Add request/response buffer limit

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -68,15 +68,15 @@ const (
 	keyResponse = "key_dumped_response"
 )
 
-func Dump() gin.HandlerFunc {
+func Dump(maxReqRespSize int) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// request
-		reqBody := new(bytes.Buffer)
+		reqBody := NewLimitedBuffer(maxReqRespSize)
 		r := io.TeeReader(c.Request.Body, reqBody)
 		c.Request.Body = ioutil.NopCloser(r)
 
 		// response
-		resBody := new(bytes.Buffer)
+		resBody := NewLimitedBuffer(maxReqRespSize)
 		w := &responseWriter{
 			dumpWriter:     resBody,
 			ResponseWriter: c.Writer,

--- a/limitedbuffer.go
+++ b/limitedbuffer.go
@@ -1,0 +1,44 @@
+package gindump
+
+import "bytes"
+
+// LimitedBuffer is a wrapper of bytes.Buffer which limits its size.
+// The buffer will store no more than the specified size, and discards the rest.
+// This is useful for preventing gindump from storing large request/response body in memory.
+// LimitedBuffer implements Writer and Reader interface.
+type LimitedBuffer struct {
+	buf bytes.Buffer
+	size int
+}
+
+// Create a new LimitedBuffer with a limited size in bytes.
+func NewLimitedBuffer(size int) *LimitedBuffer {
+	return &LimitedBuffer{
+		buf: bytes.Buffer{},
+		size: size,
+	}
+}
+
+// Read implements the io.Reader interface.
+func (lb *LimitedBuffer) Read(p []byte) (n int, err error) {
+	return lb.buf.Read(p)
+}
+
+// Write implements the io.Writer interface.
+func (lb *LimitedBuffer) Write(p []byte) (n int, err error) {
+	if lb.buf.Len() >= lb.size {
+		// 無視
+		return 0, nil
+	}
+
+	sizeToWrite := lb.size - lb.buf.Len()
+	if sizeToWrite >= len(p) {
+		sizeToWrite = len(p)
+	}
+	return lb.buf.Write(p[:sizeToWrite])
+}
+
+// Bytes returns the bytes of the underlying buffer.
+func (lb *LimitedBuffer) Bytes() []byte {
+	return lb.buf.Bytes()
+}

--- a/limitedbuffer.go
+++ b/limitedbuffer.go
@@ -27,7 +27,6 @@ func (lb *LimitedBuffer) Read(p []byte) (n int, err error) {
 // Write implements the io.Writer interface.
 func (lb *LimitedBuffer) Write(p []byte) (n int, err error) {
 	if lb.buf.Len() >= lb.size {
-		// 無視
 		return 0, nil
 	}
 


### PR DESCRIPTION
HTTP may have a large request body (e.g, file upload) or response body (e.g, file download). Gindump copies all of them to its internal buffer which will cause a lot of memory being used for dumping requests/responses. 

This PR introduces a limited buffer, which will record only a fixed size of the request/response, and discards the rest. The buffer size limit can be configured by the middleware user. This will prevent large data from overflowing the server's memory. What do you think? :dog:

 